### PR TITLE
Fix burrow checker diagram

### DIFF
--- a/second-edition/src/ch10-03-lifetime-syntax.md
+++ b/second-edition/src/ch10-03-lifetime-syntax.md
@@ -81,16 +81,16 @@ Listing 10-18 with annotations showing the lifetimes of the variables:
 
 ```rust,ignore
 {
-    let r;         // -------+-- 'a
-                   //        |
-    {              //        |
-        let x = 5; // -+-----+-- 'b
-        r = &x;    //  |     |
-    }              // -+     |
-                   //        |
-    println!("r: {}", r); // |
-                   //        |
-                   // -------+
+    let r;                // -------+-- 'a
+                          //        |
+    {                     //        |
+        let x = 5;        // -+-----+-- 'b
+        r = &x;           //  |     |
+    }                     // -+     |
+                          //        |
+    println!("r: {}", r); //        |
+                          //        |
+                          // -------+
 }
 ```
 


### PR DESCRIPTION
Improved legibility of the first burrow checker diagram. Makes the spacing/style consistent with the second diagram.
